### PR TITLE
Revert "Deal with nodata values"

### DIFF
--- a/streamer/cogeo.py
+++ b/streamer/cogeo.py
@@ -17,7 +17,7 @@ def cog_translate(
     dst_path,
     dst_kwargs,
     indexes=None,
-    nodata='auto',
+    nodata=None,
     alpha=None,
     overview_level=5,
     overview_resampling=None,
@@ -54,9 +54,6 @@ def cog_translate(
 
             indexes = indexes if indexes else src.indexes
             meta = src.meta
-            if nodata == 'auto':
-                nodata = meta.get('nodata', None)
-
             meta["count"] = len(indexes)
             meta.pop("nodata", None)
             meta.pop("alpha", None)

--- a/streamer/streamer.py
+++ b/streamer/streamer.py
@@ -52,12 +52,10 @@ class COGNetCDF:
     """
 
     def __init__(self, black_list=None, white_list=None, nonpym_list=None, default_rsp=None,
-                 src_nodata='auto',
                  bands_rsp=None, dest_template=None, src_template=None, predictor=None):
         self.nonpym_list = nonpym_list
         self.black_list = black_list
         self.white_list = white_list
-        self.src_nodata = src_nodata
         if predictor is None:
             self.predictor = 2
         else:
@@ -243,7 +241,6 @@ class COGNetCDF:
                               default_profile,
                               indexes=[i + 1],
                               overview_resampling=resampling_method,
-                              nodata=self.src_nodata,
                               overview_level=5,
                               config=DEFAULT_GDAL_CONFIG)
 


### PR DESCRIPTION
The `nodata` mask doesn't work in building overview. It should be set as the parameter when write the data in file (or memory) such that `build_overview` of `rastrio` will work properly. 