### PR TITLE
Patch cog stackfiles

### DIFF
--- a/converter/cog_conv_app.py
+++ b/converter/cog_conv_app.py
@@ -671,7 +671,7 @@ def qsub_cog_convert(product_name, time_range, config, output_dir, queue, projec
                       email_options=email_options,
                       email_id=email_id,
                       ncpus=nodes * 16,
-                      mem=nodes * 31,
+                      mem=nodes * 62,
                       walltime=walltime,
                       cog_converter_file=COG_FILE_PATH,
                       yaml_file=config,

--- a/converter/cogeo.py
+++ b/converter/cogeo.py
@@ -185,6 +185,7 @@ class COGNetCDF:
         if self.nonpym_list is not None:
             self.nonpym_list = "|".join(self.nonpym_list)
 
+        rastercount = 1
         for dts in subdatasets[:-1]:
             rastercount = gdal.Open(dts[0]).RasterCount
             for i in range(rastercount):


### PR DESCRIPTION
# Request for this pull request
Initial allocated memory of `31GB` per `CPU` would work fine with smaller `netCDF` files, however `cog` conversion fails if we input `stacked` `netCDF` files.
Also, insufficient memory also resulted in `cog` `conversion` errors while copying source overviews.

# Proposed  solution
1) Increase memory to `62GB` per `Node`.
2) Enable `copy_src_overviews` to true as part of `default profile template` instead of enabling them within `rasterio.shutil.copy` process.