### PR TITLE
Distribute mpirun program across multiple nodes and fix openmpi integration issue with dea module

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,9 +259,27 @@ Options:
 ```
 
 #### Example
-``
-mpirun python3 converter/cog_conv_app.py mpi-cog-convert -c aws_products_config.yaml
---output-dir /tmp/wofls_cog/ -p wofs_albers /tmp/wofs_albers_file_list``
+```
+#!/bin/bash
+#PBS -q normal
+#PBS -l walltime=20:00:00
+#PBS -l ncpus=256
+#PBS -l mem=256GB
+#PBS -l jobfs=1GB
+#PBS -l wd
+module use /g/data/v10/public/modules/modulefiles/
+module load dea/20181015
+module load openmpi/3.1.2
+mpirun -np 32 --map-by node:PE=8 --tag-output --report-bindings --rank-by core python3 converter/cog_conv_app.py
+mpi-cog-convert -c aws_products_config.yaml --output-dir /tmp/wofls_cog/ -p wofs_albers /tmp/wofs_albers_file_list
+
+       OR
+
+qsub -q express -N mpi_cog_convert_product -l ncpus=256,mem=496gb,jobfs=32GB,walltime=05:00:00,wd -- /bin/bash -l -c
+"module use /g/data/v10/public/modules/modulefiles/; module load dea; module load openmpi/3.1.2;
+mpirun -np 32 --map-by node:PE=8 --tag-output --report-bindings --rank-by core python3 converter/cog_conv_app.py
+mpi-cog-convert -c aws_products_config.yaml --output-dir /tmp/wofls_cog/ -p wofs_albers /tmp/wofs_albers_file_list"
+```
 
 
 ### Command: `qsub-cog-convert`

--- a/README.md
+++ b/README.md
@@ -326,8 +326,9 @@ Options:
   -o, --output-dir TEXT           Output work directory (Optional)
   -q, --queue                     [normal|express]
   -P, --project TEXT              Project Name
-  -n, --nodes INTEGER RANGE       Number of nodes to request (Optional)
   -t, --walltime INTEGER RANGE    Number of hours (range: 1-48hrs) to request (Optional)
+  --nodes INTEGER RANGE           Number of raijin nodes (range: 1-3592) to request (Optional)
+  --cores INTEGER RANGE           Number of cores per socket (range: 1-8) to request (Optional)
   -m, --email-options             [a|b|e|n|ae|ab|be|abe]
                                   Send email when execution is, 
                                   [a = aborted | b = begins | e = ends | n = do not send email]

--- a/README.md
+++ b/README.md
@@ -270,14 +270,14 @@ Options:
 module use /g/data/v10/public/modules/modulefiles/
 module load dea/20181015
 module load openmpi/3.1.2
-mpirun -np 32 --map-by node:PE=8 --tag-output --report-bindings --rank-by core python3 converter/cog_conv_app.py
+mpirun --tag-output --report-bindings --rank-by core python3 converter/cog_conv_app.py
 mpi-cog-convert -c aws_products_config.yaml --output-dir /tmp/wofls_cog/ -p wofs_albers /tmp/wofs_albers_file_list
 
        OR
 
 qsub -q express -N mpi_cog_convert_product -l ncpus=256,mem=496gb,jobfs=32GB,walltime=05:00:00,wd -- /bin/bash -l -c
 "module use /g/data/v10/public/modules/modulefiles/; module load dea; module load openmpi/3.1.2;
-mpirun -np 32 --map-by node:PE=8 --tag-output --report-bindings --rank-by core python3 converter/cog_conv_app.py
+mpirun --tag-output --report-bindings --rank-by core python3 converter/cog_conv_app.py
 mpi-cog-convert -c aws_products_config.yaml --output-dir /tmp/wofls_cog/ -p wofs_albers /tmp/wofs_albers_file_list"
 ```
 

--- a/README.md
+++ b/README.md
@@ -263,8 +263,8 @@ Options:
 #!/bin/bash
 #PBS -q normal
 #PBS -l walltime=20:00:00
-#PBS -l ncpus=256
-#PBS -l mem=256GB
+#PBS -l ncpus=80
+#PBS -l mem=155GB
 #PBS -l jobfs=1GB
 #PBS -l wd
 module use /g/data/v10/public/modules/modulefiles/
@@ -275,7 +275,7 @@ mpi-cog-convert -c aws_products_config.yaml --output-dir /tmp/wofls_cog/ -p wofs
 
        OR
 
-qsub -q express -N mpi_cog_convert_product -l ncpus=256,mem=496gb,jobfs=32GB,walltime=05:00:00,wd -- /bin/bash -l -c
+qsub -q express -N mpi_cog_convert_product -l ncpus=80,mem=155gb,jobfs=32GB,walltime=05:00:00,wd -- /bin/bash -l -c
 "module use /g/data/v10/public/modules/modulefiles/; module load dea; module load openmpi/3.1.2;
 mpirun --tag-output --report-bindings --rank-by core python3 converter/cog_conv_app.py
 mpi-cog-convert -c aws_products_config.yaml --output-dir /tmp/wofls_cog/ -p wofs_albers /tmp/wofs_albers_file_list"

--- a/README.md
+++ b/README.md
@@ -328,7 +328,6 @@ Options:
   -P, --project TEXT              Project Name
   -t, --walltime INTEGER RANGE    Number of hours (range: 1-48hrs) to request (Optional)
   --nodes INTEGER RANGE           Number of raijin nodes (range: 1-3592) to request (Optional)
-  --cores INTEGER RANGE           Number of cores per socket (range: 1-8) to request (Optional)
   -m, --email-options             [a|b|e|n|ae|ab|be|abe]
                                   Send email when execution is, 
                                   [a = aborted | b = begins | e = ends | n = do not send email]

--- a/converter/cog_conv_app.py
+++ b/converter/cog_conv_app.py
@@ -99,7 +99,7 @@ config_file_options = click.option('--config', '-c', default=YAMLFILE_PATH,
 
 # pylint: disable=invalid-name
 # https://cs.anu.edu.au/courses/distMemHPC/sessions/MF1.html
-num_nodes_options = click.option('--nodes', default=31,
+num_nodes_options = click.option('--nodes', default=5,
                                  help='Number of raijin nodes (range: 1-3592) to request (Optional)',
                                  type=click.IntRange(1, 3592))
 
@@ -680,7 +680,7 @@ def qsub_cog_convert(product_name, time_range, config, output_dir, queue, projec
                       email_options=email_options,
                       email_id=email_id,
                       ncpus=nodes * 16,
-                      mem=nodes * 16 * 4,
+                      mem=nodes * 62,
                       walltime=walltime,
                       cog_converter_file=COG_FILE_PATH,
                       yaml_file=config,

--- a/converter/cog_conv_app.py
+++ b/converter/cog_conv_app.py
@@ -645,7 +645,7 @@ def qsub_cog_convert(product_name, time_range, config, output_dir, queue, projec
 
     prep = 'qsub -q %(queue)s -N generate_work_list_%(product)s -P %(project)s ' \
            '-W depend=afterok:%(s3_inv_job)s: -l wd,walltime=10:00:00,mem=31GB,jobfs=5GB -W umask=33 ' \
-           '-- /bin/bash -l -c "source $HOME/.bashrc;' \
+           '-- /bin/bash -l -c "source $HOME/.bashrc; ' \
            '%(generate_script)s --dea-module %(dea_module)s --cog-file %(cog_converter_file)s ' \
            '--config-file %(yaml_file)s --product-name %(product)s --output-dir %(output_dir)s ' \
            '--datacube-env %(dc_env)s --s3-list %(pickle_file)s --time-range \'%(time_range)s\'"'
@@ -663,8 +663,8 @@ def qsub_cog_convert(product_name, time_range, config, output_dir, queue, projec
            '-- /bin/bash -l -c "source $HOME/.bashrc; ' \
            'module use /g/data/v10/public/modules/modulefiles/; ' \
            'module load dea; ' \
-           'mpirun --tag-output python3 %(cog_converter_file)s mpi-cog-convert -c %(yaml_file)s ' \
-           '--output-dir %(output_dir)s --product-name %(product)s %(file_list)s"'
+           'mpirun --tag-output --oversubscribe -n %(ncpus)d python3 %(cog_converter_file)s mpi-cog-convert ' \
+           '-c %(yaml_file)s --output-dir %(output_dir)s --product-name %(product)s %(file_list)s"'
     cmd = qsub % dict(queue=queue,
                       project=project,
                       file_list_job=file_list_job.split('.')[0],

--- a/converter/cog_conv_app.py
+++ b/converter/cog_conv_app.py
@@ -106,8 +106,8 @@ num_nodes_options = click.option('--nodes', default=16,
 # pylint: disable=invalid-name
 # https://cs.anu.edu.au/courses/distMemHPC/sessions/MF1.html
 num_cores_options = click.option('--cores', default=8,
-                                 help='Number of cores per processes (range: 1-57472) to request (Optional)',
-                                 type=click.IntRange(1, 57472))
+                                 help='Number of cores per socket (range: 1-8) to request (Optional)',
+                                 type=click.IntRange(1, 8))
 
 with open(ROOT_DIR / 'aws_products_config.yaml') as fd:
     CFG = yaml.load(fd)

--- a/converter/cog_conv_app.py
+++ b/converter/cog_conv_app.py
@@ -99,7 +99,7 @@ config_file_options = click.option('--config', '-c', default=YAMLFILE_PATH,
 
 # pylint: disable=invalid-name
 # https://cs.anu.edu.au/courses/distMemHPC/sessions/MF1.html
-num_nodes_options = click.option('--nodes', default=16,
+num_nodes_options = click.option('--nodes', default=31,
                                  help='Number of raijin nodes (range: 1-3592) to request (Optional)',
                                  type=click.IntRange(1, 3592))
 

--- a/converter/mpi_cog_convert.sh
+++ b/converter/mpi_cog_convert.sh
@@ -36,6 +36,8 @@ while [[ "$#" -gt 0 ]]; do
     shift
 done
 
+[ -d "$OUTDIR" ] || mkdir -p "$OUTDIR"
+
 FILEL=$OUTDIR/file_list_
 FILEN=$OUTDIR/file_empty_list
 NNODES=31
@@ -78,6 +80,8 @@ f_j=$(qsub -P "$PROJECT" -q "$QUEUE" \
       mpirun --tag-output --report-bindings python3 $COGS mpi-convert-cog -c $YAMLFILE --output-dir $OUTDIR \
       --product-name $PRODUCT $FILEL$j")
 
+echo "Submitting qsub job, $f_j"
+
 j=2
 while [ -s  "$FILEL$j" ]; do
     n_j=$(qsub -W depend=afterany:"$f_j" -P "$PROJECT" -q "$QUEUE" \
@@ -90,4 +94,5 @@ while [ -s  "$FILEL$j" ]; do
           --output-dir $OUTDIR --product-name $PRODUCT $FILEL$j")
     f_j=$n_j
     j=$((j+1))
+    echo "Submitting qsub job, $f_j"
 done


### PR DESCRIPTION
# Proposed changes
1. Load `openmpi/3.1.2` on top of `dea/20181015` to enable `mpirun` program run across multiple nodes.
2. Update documentation in `README.md` to reflect latest changes.
3. Make number of nodes configurable in `converter/cog_conv_app.py` file.
4. Update cog conversion script (`converter/mpi_cog_convert.sh`) for the latest changes.
5. In `converter/mpi_cog_convert.sh` script add a line to create an output directory if it does not exists.