### PR TITLE
Patch cog conversion app

### DIFF
--- a/converter/cog_conv_app.py
+++ b/converter/cog_conv_app.py
@@ -494,7 +494,7 @@ def verify(path, rm_broken):
 
     if path.is_dir():
         # Non-lazy recursive search for geotiffs
-        gtiff_file_list = Path(path).rglob("*.tif")
+        gtiff_file_list = Path(path).rglob("*.[tT][iI][fF]")
         gtiff_file_list = list(gtiff_file_list)
     else:
         # Read filenames to check from a file

--- a/converter/cogeo.py
+++ b/converter/cogeo.py
@@ -84,7 +84,7 @@ class NetCDFCOGConverter:
             _, part_index = part_no.split('=')
             part_index = int(part_index)
 
-        if not input_file.endswith('.nc'):
+        if not Path(input_file).match("*.[nN][cC]"):
             raise COGException("COG Converter only works with NetCDF datasets.")
 
         yaml_fname = output_prefix.with_suffix('.yaml')
@@ -124,7 +124,6 @@ class NetCDFCOGConverter:
                     invalid_band.append(band_name)
                     continue
 
-            # TODO WTF
             if self.white_list is not None:
                 if re.search(self.white_list, band_name) is None:
                     invalid_band.append(band_name)
@@ -238,7 +237,9 @@ def cog_translate(
     src = gdal.Open(src_path, gdal.GA_ReadOnly)
     band = src.GetRasterBand(1)
     nodata = band.GetNoDataValue()
-    if band.DataType == gdal.GDT_Byte and band.GetNoDataValue() < 0:
+
+    # Update nodata mask only if nodata is a negative integer value
+    if band.DataType == gdal.GDT_Byte and nodata and nodata < 0:
         nodata_mask = 255
 
     with rasterio.Env(**config):

--- a/converter/run_cogger.sh
+++ b/converter/run_cogger.sh
@@ -6,8 +6,8 @@
 #PBS -W umask=33
 #PBS -m abe -M nci.monitor@dea.ga.gov.au
 
-## specify PRODUCT, OUTPUT_DIR, and FILE_LIST using qsub -v option
-## eg qsub -v PRODUCT=ls7_fc_albers,OUTPUT_DIR=/outdir/ls7,FILE_LIST=/outdir/ls7_fc_albers.txt run_cogger.sh
+## specify PRODUCT, OUTPUT_DIR, ROOT_DIR, and FILE_LIST using qsub -v option
+## eg qsub -v PRODUCT=ls7_fc_albers,OUTPUT_DIR=/odir/ls7,FILE_LIST=/odir/ls7_fc_albers.txt,ROOT_DIR=/g/foo run_cogger.sh
 
 set -xe
 
@@ -16,4 +16,4 @@ module use /g/data/v10/public/modules/modulefiles/
 module load dea
 module load openmpi/3.1.2
 
-mpirun --tag-output python3 cog_conv_app.py mpi-convert -p "${PRODUCT}" -o "${OUTPUT_DIR}" "${FILE_LIST}"
+mpirun --tag-output python3 "${ROOT_DIR}"/cog_conv_app.py mpi-convert -p "${PRODUCT}" -o "${OUTPUT_DIR}" "${FILE_LIST}"

--- a/converter/run_generate_work_list.sh
+++ b/converter/run_generate_work_list.sh
@@ -21,5 +21,5 @@ cd "$OUTPUT_DIR" || {
   exit 1
 }
 
-python3 "$ROOT_DIR"/cog_conv_app.py generate-work-list --config "$ROOT_DIR"/aws_products_config.yaml \
+python3 "${ROOT_DIR}"/cog_conv_app.py generate-work-list --config "${ROOT_DIR}"/aws_products_config.yaml \
 --product-name "$PRODUCT_NAME" --time-range "$TIME_RANGE" --output-dir "$OUTPUT_DIR" --pickle-file "$PICKLE_FILE"

--- a/converter/run_s3_upload.sh
+++ b/converter/run_s3_upload.sh
@@ -6,7 +6,7 @@
 #PBS -m abe -M nci.monitor@dea.ga.gov.au
 
 ## specify AWS_PROFILE, OUT_DIR, and S3_BUCKET using qsub -v option
-## eg qsub -v AWS_PROFILE='default',OUT_DIR=/tempdir/,S3_BUCKET='s3://bucketname/' run_aws_sync.sh
+## eg qsub -v AWS_PROFILE='default',OUT_DIR=/tempdir/,S3_BUCKET='s3://bucketname/' run_s3_upload.sh
 
 set -xe
 

--- a/converter/run_save_task.sh
+++ b/converter/run_save_task.sh
@@ -5,8 +5,8 @@
 #PBS -W umask=33
 #PBS -m abe -M nci.monitor@dea.ga.gov.au
 
-## specify PRODUCT, S3_INV, and OUT_DIR using qsub -v option
-## eg qsub -v PRODUCT=ls8_fc_albers,OUT_DIR='/tempdir/',S3_INV='s3://bucket/' run_save_task.sh
+## specify PRODUCT, S3_INV, ROOT_DIR, and OUT_DIR using qsub -v option
+## eg qsub -v PRODUCT=ls8_fc_albers,OUT_DIR='/tempdir/',S3_INV='s3://bucket/',ROOT_DIR=/g/data/foo run_save_task.sh
 
 set -xe
 
@@ -14,4 +14,5 @@ source "$HOME"/.bashrc
 module use /g/data/v10/public/modules/modulefiles
 module load dea
 
-python3 cog_conv_app.py save-s3-inventory -p "${PRODUCT}" -o "${OUT_DIR}" -c aws_products_config.yaml
+python3 "${ROOT_DIR}"/cog_conv_app.py save-s3-inventory -p "${PRODUCT}" -o "${OUT_DIR}" \
+-c "${ROOT_DIR}"/aws_products_config.yaml

--- a/converter/run_verify.sh
+++ b/converter/run_verify.sh
@@ -6,8 +6,8 @@
 #PBS -W umask=33
 #PBS -m abe -M nci.monitor@dea.ga.gov.au
 
-## specify OUTPUT_DIR using qsub -v option
-## eg qsub -v OUTPUT_DIR=/outdir/ls7 run_verify.sh
+## specify OUTPUT_DIR and ROOT_DIR using qsub -v option
+## eg qsub -v OUTPUT_DIR=/outdir/ls7,ROOT_DIR=/g/data/foo run_verify.sh
 
 set -xe
 
@@ -16,4 +16,4 @@ module use /g/data/v10/public/modules/modulefiles/
 module load dea
 module load openmpi/3.1.2
 
-mpirun --tag-output python3 cog_conv_app.py verify --rm-broken "${OUTPUT_DIR}"
+mpirun --tag-output python3 "${ROOT_DIR}"/cog_conv_app.py verify --rm-broken "${OUTPUT_DIR}"


### PR DESCRIPTION
# Reason for pull request
Some of the bands within the source datasets had `None` as the no data value. Additional check within the code is required to ensure that `nodata_mask` is updated to a value `255` for a negative integer values only.

Also, the files referenced within `qsub-cog` app is `relative` meaning the same app does not work as expected when we run the `qsub-cog` command from a different directory. To solve this, make all the file references within the app as `absolute`.

# Proposed solution
1. Update `nodata_mask` to a value `255` only when we have negative band value.
2. Make changes to glob the relative pattern for `*.tif or *.TIF` files and `*.nc or *.NC` files.
3. Update all file references as `absolute`.