### PR TITLE
Cog new ard collection upgrade sample

### DIFF
--- a/converter/aws_products_config.yaml
+++ b/converter/aws_products_config.yaml
@@ -95,3 +95,18 @@ products:
     prefix: mangrove_cover
     name_template: "{x}_{y}/MANGROVE_COVER_3577_{x}_{y}_{time:%Y%m%d}"
     default_resampling: average
+
+  ga_ls5t_ard_3:
+    prefix: ga_landsat_ard_3/ga_ls5t_ard_3/v3.0.0
+    name_template: x_{x}/y_{y}/{time:%Y/%m/%d}
+    default_resampling: average
+
+  ga_ls7t_ard_3:
+    prefix: ga_landsat_ard_3/ga_ls7t_ard_3/v3.0.0
+    name_template: x_{x}/y_{y}/{time:%Y/%m/%d}
+    default_resampling: average
+
+  ga_ls8t_ard_3:
+    prefix: ga_landsat_ard_3/ga_ls8t_ard_3/v3.0.0
+    name_template: x_{x}/y_{y}/{time:%Y/%m/%d}
+    default_resampling: average

--- a/converter/aws_products_config.yaml
+++ b/converter/aws_products_config.yaml
@@ -98,15 +98,15 @@ products:
 
   ga_ls5t_ard_3:
     prefix: ga_landsat_ard_3/ga_ls5t_ard_3/v3.0.0
-    name_template: x_{x}/y_{y}/{time:%Y/%m/%d}
+    name_template: {x}/{y}/{time:%Y/%m/%d}
     default_resampling: average
 
   ga_ls7t_ard_3:
     prefix: ga_landsat_ard_3/ga_ls7t_ard_3/v3.0.0
-    name_template: x_{x}/y_{y}/{time:%Y/%m/%d}
+    name_template: {x}/{y}/{time:%Y/%m/%d}
     default_resampling: average
 
   ga_ls8t_ard_3:
     prefix: ga_landsat_ard_3/ga_ls8t_ard_3/v3.0.0
-    name_template: x_{x}/y_{y}/{time:%Y/%m/%d}
+    name_template: {x}/{y}/{time:%Y/%m/%d}
     default_resampling: average

--- a/converter/aws_products_config.yaml
+++ b/converter/aws_products_config.yaml
@@ -97,16 +97,16 @@ products:
     default_resampling: average
 
   ga_ls5t_ard_3:
-    prefix: ga_landsat_ard_3/ga_ls5t_ard_3/v3.0.0
+    prefix: ga_landsat_ard_3/v3.0.0/ga_ls5t_ard_3
     name_template: {x}/{y}/{time:%Y/%m/%d}
     default_resampling: average
 
   ga_ls7t_ard_3:
-    prefix: ga_landsat_ard_3/ga_ls7t_ard_3/v3.0.0
+    prefix: ga_landsat_ard_3/v3.0.0/ga_ls7t_ard_3
     name_template: {x}/{y}/{time:%Y/%m/%d}
     default_resampling: average
 
   ga_ls8t_ard_3:
-    prefix: ga_landsat_ard_3/ga_ls8t_ard_3/v3.0.0
+    prefix: ga_landsat_ard_3/v3.0.0/ga_ls8t_ard_3
     name_template: {x}/{y}/{time:%Y/%m/%d}
     default_resampling: average

--- a/converter/aws_products_config.yaml
+++ b/converter/aws_products_config.yaml
@@ -97,16 +97,16 @@ products:
     default_resampling: average
 
   ga_ls5t_ard_3:
-    prefix: ga_landsat_ard_3/v3.0.0/ga_ls5t_ard_3
-    name_template: {x}/{y}/{time:%Y/%m/%d}
+    prefix: ga_landsat_ard_3/v3.0.0
+    name_template: ga_ls5t_ard_3/{x}/{y}/{time:%Y/%m/%d}
     default_resampling: average
 
-  ga_ls7t_ard_3:
-    prefix: ga_landsat_ard_3/v3.0.0/ga_ls7t_ard_3
-    name_template: {x}/{y}/{time:%Y/%m/%d}
+  ga_ls7e_ard_3:
+    prefix: ga_landsat_ard_3/v3.0.0
+    name_template: ga_ls7e_ard_3/{x}/{y}/{time:%Y/%m/%d}
     default_resampling: average
 
-  ga_ls8t_ard_3:
-    prefix: ga_landsat_ard_3/v3.0.0/ga_ls8t_ard_3
-    name_template: {x}/{y}/{time:%Y/%m/%d}
+  ga_ls8c_ard_3:
+    prefix: ga_landsat_ard_3/v3.0.0
+    name_template: ga_ls8c_ard_3/{x}/{y}/{time:%Y/%m/%d}
     default_resampling: average

--- a/converter/cog_conv_app.py
+++ b/converter/cog_conv_app.py
@@ -690,7 +690,7 @@ def qsub_cog(product_name, s3_output_url, output_dir, time_range, inventory_mani
     # Make output directory specific to the a product (if it does not exists)
     work_dir.mkdir(parents=True, exist_ok=True)
 
-    if product_name in ('ga_ls5t_ard_3', 'ga_ls7t_ard_3', 'ga_ls8t_ard_3'):
+    if product_name in ('ga_ls5t_ard_3', 'ga_ls7e_ard_3', 'ga_ls8c_ard_3'):
         try:
             Path(task_file).unlink()  # Remove task file if it exists
         except FileNotFoundError:
@@ -724,7 +724,7 @@ def qsub_cog(product_name, s3_output_url, output_dir, time_range, inventory_mani
         file_list_job = _submit_qsub_job(
             f'qsub -N generate_work_list_{product_name} -W depend=afterok:{s3_inv_job}: '
             f'-v PRODUCT_NAME={product_name},OUTPUT_DIR={work_dir.parent},ROOT_DIR={ROOT_DIR},'
-            f'TIME_RANGE=\'{time_range}\',PICKLE_FILE={pickle_file.as_posix()} {ROOT_DIR}/run_generate_work_list.sh'
+            f'TIME_RANGE=\'{time_range}\',PICKLE_FILE={pickle_file} {ROOT_DIR}/run_generate_work_list.sh'
         )
 
     # Run cogger

--- a/converter/cog_conv_app.py
+++ b/converter/cog_conv_app.py
@@ -744,7 +744,7 @@ def qsub_cog(product_name, s3_output_url, output_dir, time_range, inventory_mani
     # Verify the converted cog files are in correct format
     # language=bash
     verify_job = _submit_qsub_job(
-        f'qsub -N verify_{product_name} -W depend=afterany:{cogger_job}: -v OUTPUT_DIR={output_dir},'
+        f'qsub -N verify_{product_name} -W depend=afterany:{cogger_job}: -v OUTPUT_DIR={work_dir},'
         f'ROOT_DIR={ROOT_DIR} {ROOT_DIR}/run_verify.sh'
     )
 

--- a/converter/run_cogger.sh
+++ b/converter/run_cogger.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-#PBS -l wd,walltime=5:00:00,mem=6200GB,ncpus=1600,jobfs=1GB
+#PBS -l wd,walltime=5:00:00,mem=6200GB,ncpus=1600,jobfs=2GB
 #PBS -P v10
 #PBS -q normal
 #PBS -lother=gdata1:gdata2

--- a/converter/run_s3_upload.sh
+++ b/converter/run_s3_upload.sh
@@ -41,7 +41,7 @@ if [[ -s ~/.aws/credentials ]]; then
 
         # Recursively sync all the files under a specified directory to S3 bucket excluding specified file formats
         aws s3 sync "$OUT_DIR" "$S3_BUCKET" --exclude "*.pickle" --exclude "*.txt" --exclude "*file_list*" \
-        --exclude "*.log"
+        --exclude "*.log" --exclude '*.xml'
 
         # Remove cog converted files after aws s3 sync
         rm -r "$OUT_DIR"


### PR DESCRIPTION
# Abstract for this pull request
Existing `cog` conversion tool only works on `netCDF` file. Update the code to cog `tif` files as per `odc-metadata` document and also generate a legacy `metadata` file that is compatible with `datacube rc1.7`.

# Proposed solutions
1) Add new ard sample product configurations in `converter/aws_products_config.yaml` file
2) Update the `qsub-cog` function in `converter/cog_conv_app.py` file, to scan the `*odc-metadata.yaml` file and generate work list. Also, add new code for creating the legacy metadata file for `datacube` `indexing` purpose.
3) Add logic to convert `tif` files to `geotiff` files in `converter/cogeo.py` file.
