### PR TITLE
Gadi migration changes

### DIFF
--- a/converter/cog_conv_app.py
+++ b/converter/cog_conv_app.py
@@ -411,7 +411,7 @@ def mpi_convert(product_name, output_dir, config, filelist):
     Before using this command, execute the following:
       $ module use /g/data/v10/public/modules/modulefiles/
       $ module load dea
-      $ module load openmpi/3.1.2
+      $ module load openmpi/4.0.1
     """
     job_rank, job_size = _mpi_init()
 

--- a/converter/run_cogger.sh
+++ b/converter/run_cogger.sh
@@ -14,6 +14,6 @@ set -xe
 source "$HOME/.bashrc"
 module use /g/data/v10/public/modules/modulefiles/
 module load dea
-module load openmpi/3.1.2
+module load openmpi/4.0.1
 
 mpirun --tag-output python3 "${ROOT_DIR}"/cog_conv_app.py mpi-convert -p "${PRODUCT}" -o "${OUTPUT_DIR}" "${FILE_LIST}"

--- a/converter/run_cogger.sh
+++ b/converter/run_cogger.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-#PBS -l wd,walltime=5:00:00,mem=6200GB,ncpus=1600,jobfs=1GB
+#PBS -l wd,walltime=10:00:00,mem=4000GB,ncpus=1200,jobfs=5GB
 #PBS -P v10
 #PBS -q normal
 #PBS -lother=gdata1:gdata2

--- a/converter/run_generate_work_list.sh
+++ b/converter/run_generate_work_list.sh
@@ -14,7 +14,7 @@ set -xe
 source "$HOME/.bashrc"
 module use /g/data/v10/public/modules/modulefiles/
 module load dea
-module load openmpi/3.1.2
+module load openmpi/4.0.1
 
 cd "$OUTPUT_DIR" || {
   echo "$OUTPUT_DIR" path does not exists

--- a/converter/run_verify.sh
+++ b/converter/run_verify.sh
@@ -14,6 +14,6 @@ set -xe
 source "$HOME/.bashrc"
 module use /g/data/v10/public/modules/modulefiles/
 module load dea
-module load openmpi/3.1.2
+module load openmpi/4.0.1
 
 mpirun --tag-output python3 "${ROOT_DIR}"/cog_conv_app.py verify --rm-broken "${OUTPUT_DIR}"


### PR DESCRIPTION
## Updates in this PR
- Update the requested number of cpus value that is a multiple of 48 cpus (`1200 ncpus`)
- Reduce the requested memory per job to be `4000GB` for the job
- Use latest openmpi version available on Gadi